### PR TITLE
align barretenberg-rs version with noir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ tracing-subscriber = "0.3"
 serde_json = "1.0.125"
 
 # Optional dependencies
-barretenberg-rs = { version = "=4.2.0-aztecnr-rc.2", default-features = false, features = ["ffi"], optional = true }
+barretenberg-rs = { version = "=5.0.0-nightly.20260512", default-features = false, features = ["ffi"], optional = true }
 [features]
 default = []
 barretenberg = ["barretenberg-rs"]


### PR DESCRIPTION
Update barretenberg-rs from 4.2.0-aztecnr-rc.2 to 5.0.0-nightly.20260512 per the official barretenberg version mapping for noir 1.0.0-beta.20.